### PR TITLE
Clang compatibility

### DIFF
--- a/multicore_tsne/quadtree.h
+++ b/multicore_tsne/quadtree.h
@@ -14,7 +14,6 @@
 
 static inline double min(double x, double y) { return (x <= y ? x : y); }
 static inline double max(double x, double y) { return (x <= y ? y : x); }
-static inline double abs(double x) { return (x < .0 ? -x : x); }
 
 class Cell {
 

--- a/multicore_tsne/tsne.cpp
+++ b/multicore_tsne/tsne.cpp
@@ -134,7 +134,7 @@ void TSNE::run(double* X, int N, int D, double* Y, int no_dims, double perplexit
         }
 
         // Print out progress
-        if (iter > 0 && iter % 50 == 0 || iter == max_iter - 1) {
+        if ((iter > 0 && iter % 50 == 0) || (iter == max_iter - 1)) {
             end = time(0);
             double C = .0;
 


### PR DESCRIPTION
- abs is unused code, and causes compilation failure for Clang
- brackets to disambiguate conditionals in order to suppress Clang compiler warning ("place parentheses around the '&&' expression to silence this warning")