### PR TITLE
package is now pip-installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+python/tests/mnist.pkl.gz

--- a/README.md
+++ b/README.md
@@ -49,19 +49,19 @@ Python and torch wrappers are available.
 ## Python
 ### Install
 
-Make sure `cmake` is installed on your system and install python prerequisites:
+Make sure `cmake` is installed on your system.
 
+To install the package please do:
 ```
-pip install -r requirements.txt
-```
-
-Then install MulticoreTSNE:
-```
-python setup.py install
+git clone https://github.com/DmitryUlyanov/Multicore-TSNE.git
+cd Multicore-TSNE/
+pip install --no-cache-dir .
 ```
 
-Pip installation does not copy `.so` file for some reason (experts wanted).
-Tested with both Python 2.7 and 3.5 (conda) and Ubuntu 14.04. Never tested on MacOS, something similar to [this](https://github.com/RobeDM/LIBIRWLS#compiling-1) should be done for successful compilation. Also read this [issue](https://github.com/DmitryUlyanov/Multicore-TSNE/issues/1).
+It's important that you add `--no-cache-dir` otherwise pip won't copy
+the `.so` file which is needed at runtime.
+
+Tested with both Python 2.7 and 3.6 (conda) and Ubuntu 14.04. Never tested on MacOS, something similar to [this](https://github.com/RobeDM/LIBIRWLS#compiling-1) should be done for successful compilation. Also read this [issue](https://github.com/DmitryUlyanov/Multicore-TSNE/issues/1).
 
 ### Run
 

--- a/python/tests/test.py
+++ b/python/tests/test.py
@@ -16,8 +16,12 @@ def get_mnist():
 
     if not os.path.exists('mnist.pkl.gz'):
         print('downloading MNIST')
-        urllib.urlretrieve(
+        if sys.version_info >= (3, 0):
+            urllib.request.urlretrieve(
             'http://deeplearning.net/data/mnist/mnist.pkl.gz', 'mnist.pkl.gz')
+        else:
+            urllib.urlretrieve(
+                        'http://deeplearning.net/data/mnist/mnist.pkl.gz', 'mnist.pkl.gz')
         print('downloaded')
 
     f = gzip.open("mnist.pkl.gz", "rb")

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-import numpy
 from setuptools import setup
-from distutils.command.install import install as DistutilsInstall
 import sys
 import os
+from setuptools.command.install import install
+
 
 '''
     Just because I wanted .so file to be built same way for python and torch
@@ -10,12 +10,27 @@ import os
 '''
 
 
-class MyInstall(DistutilsInstall):
+class MyInstall(install):
     def run(self):
-        os.system('mkdir -p multicore_tsne/release ; rm -r multicore_tsne/release/* ; cd multicore_tsne/release ; cmake -DCMAKE_BUILD_TYPE=RELEASE .. ; make VERBOSE=1')
+        if not os.path.exists('multicore_tsne/release'):
+            os.makedirs('multicore_tsne/release')
+        else:
+            os.system('rm -rf multicore_tsne/release/')
+            os.makedirs('multicore_tsne/release')
+
+        os.chdir('multicore_tsne/release/')
+        return_val = os.system('cmake -DCMAKE_BUILD_TYPE=RELEASE ..')
+
+        if return_val != 0:
+            print('cannot find cmake')
+            exit(-1)
+
+        os.system('make VERBOSE=1')
+        os.chdir('../..')
+        print(os.getcwd())
         os.system(
             'cp multicore_tsne/release/libtsne_multicore.so python/libtsne_multicore.so')
-        DistutilsInstall.run(self)
+        install.run(self)
 
 
 setup(
@@ -29,6 +44,7 @@ setup(
         'numpy',
         'psutil',
         'cffi',
+        'matplotlib',
     ],
 
     packages=['MulticoreTSNE'],

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
-from setuptools import setup
 import sys
 import os
 from setuptools.command.install import install
-
+from setuptools import setup
 
 '''
     Just because I wanted .so file to be built same way for python and torch
@@ -43,8 +42,7 @@ setup(
     install_requires=[
         'numpy',
         'psutil',
-        'cffi',
-        'matplotlib',
+        'cffi'
     ],
 
     packages=['MulticoreTSNE'],


### PR DESCRIPTION
Hi Dmtry!

This PR fixes problem #6 

I did this by using setuptools install function instead of the one contained in distutils.
In addition to that I slightly rewrote the custom install function in setup.py. This was necessary, since the original part didn't abort the installation process in the case cmake wasn't installed.
For completeness I also added a gitignore file.