### PR TITLE
fix - make sure numpy array is C_CONTIGUOUS

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -71,6 +71,10 @@ class MulticoreTSNE:
             self.n_jobs = psutil.cpu_count()
 
         assert self.n_jobs > 0, 'Wrong n_jobs parameter.'
+        
+        if (X.flags['C_CONTIGUOUS'] is False):
+        	print 'Converting input to contiguous array...'
+        	X = np.ascontiguousarray(X)
 
         N, D = X.shape
         Y = np.zeros((N, self.n_components))


### PR DESCRIPTION
In the fit_transform function in python, there is sometimes an issue with the passed numpy array.  If the array is not C_CONTIGUOUS, then when passed to C++, the data is no longer in the expected format and you get garbage results.

I found this out after loading a CSV into Pandas and then converting to a numpy array for use in Multicore TSNE.  It's quite possible that some of the reported issues (getting totally mismatched results with sklearn, projection produced is an indiscernible cloud of points, etc.) have a decent likelihood that the array was not C_CONTIGUOUS, and thus the data produced would be expected to be garbage because of the hand-off to C++.

The change is to check if the passed numpy array has the C_CONTIGUOUS flag set to false.  If so, it makes the array C_CONTIGUOUS, and proceeds with the rest of the function as normal.