### PR TITLE
remove verbose from example

### DIFF
--- a/MulticoreTSNE/examples/test.py
+++ b/MulticoreTSNE/examples/test.py
@@ -63,7 +63,7 @@ def plot(Y, classes, name):
 
 mnist, classes = get_mnist()
 
-tsne = TSNE(n_jobs=int(sys.argv[1]))
+tsne = TSNE(n_jobs=int(sys.argv[1]), verbose=1)
 mnist_tsne = tsne.fit_transform(mnist)
 
 plot(mnist_tsne, classes, 'tsne_' + sys.argv[1] + 'core.png')

--- a/MulticoreTSNE/examples/test.py
+++ b/MulticoreTSNE/examples/test.py
@@ -64,6 +64,6 @@ def plot(Y, classes, name):
 mnist, classes = get_mnist()
 
 tsne = TSNE(n_jobs=int(sys.argv[1]))
-mnist_tsne = tsne.fit_transform(mnist, verbose=1)
+mnist_tsne = tsne.fit_transform(mnist)
 
 plot(mnist_tsne, classes, 'tsne_' + sys.argv[1] + 'core.png')


### PR DESCRIPTION
Running the example as-is, I get:

```
$python MulticoreTSNE/examples/test.py 2
downloading MNIST
downloaded
Traceback (most recent call last):
  File "MulticoreTSNE/examples/test.py", line 67, in <module>
    mnist_tsne = tsne.fit_transform(mnist, verbose=1)
TypeError: fit_transform() got an unexpected keyword argument 'verbose'
```

This is not unexpected, as the `fit_transform` method does not take a `verbose` flag :)