### PR TITLE
remove installation flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,10 @@ To install the package please do:
 ```
 git clone https://github.com/DmitryUlyanov/Multicore-TSNE.git
 cd Multicore-TSNE/
-pip install --no-cache-dir .
+pip install .
 ```
 
-It's important that you add `--no-cache-dir` otherwise pip won't copy
-the `.so` file which is needed at runtime.
-
-For [installation on MacOS](https://github.com/DmitryUlyanov/Multicore-TSNE/issues/1), before running `pip install --no-cache-dir .`, you need to
+For [installation on MacOS](https://github.com/DmitryUlyanov/Multicore-TSNE/issues/1), before running `pip install .`, you need to
 * install gcc with `brew install gcc --without-multilib
 * change line 9 of [CMakeLists.txt](multicore_tsne/CMakeLists.txt) to `SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -O3 -fPIC -ffast-math -funroll-loops -lstdc++")`
 * run `export CC="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"; export CXX="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"`, where `X` and `x` refers to the version of `gcc`; in my case, e.g., the path reads `/usr/local/Cellar/gcc/6.3.0_1/bin/gcc-6`


### PR DESCRIPTION
Hi Dmitry!
It looks like the "--no-cache-dir" flag isn't necessary anymore, so I updated the documentation!
Tested on Linux & python 3.6.2