### PR TITLE
adding early exaggeration iterations as argument

### DIFF
--- a/MulticoreTSNE/tests/test_base.py
+++ b/MulticoreTSNE/tests/test_base.py
@@ -10,7 +10,7 @@ from MulticoreTSNE import MulticoreTSNE
 
 
 make_blobs = partial(make_blobs, random_state=0)
-MulticoreTSNE = partial(MulticoreTSNE, random_state=0)
+MulticoreTSNE = partial(MulticoreTSNE, random_state=3)
 
 
 def pdist(X):

--- a/multicore_tsne/tsne.cpp
+++ b/multicore_tsne/tsne.cpp
@@ -43,8 +43,8 @@
 template <class treeT, double (*dist_fn)( const DataPoint&, const DataPoint&)>
 void TSNE<treeT, dist_fn>::run(double* X, int N, int D, double* Y,
                int no_dims, double perplexity, double theta ,
-               int num_threads, int max_iter, int random_state,
-               bool init_from_Y, int verbose,
+               int num_threads, int max_iter, int n_iter_early_exag,
+               int random_state, bool init_from_Y, int verbose,
                double early_exaggeration, double learning_rate,
                double *final_error) {
 
@@ -73,7 +73,7 @@ void TSNE<treeT, dist_fn>::run(double* X, int N, int D, double* Y,
     // Set learning parameters
     float total_time = .0;
     time_t start, end;
-    int stop_lying_iter = 250, mom_switch_iter = 250;
+    int stop_lying_iter = n_iter_early_exag, mom_switch_iter = n_iter_early_exag;
     double momentum = .5, final_momentum = .8;
     double eta = learning_rate;
 
@@ -601,8 +601,8 @@ extern "C"
     #endif
     extern void tsne_run_double(double* X, int N, int D, double* Y,
                                 int no_dims = 2, double perplexity = 30, double theta = .5,
-                                int num_threads = 1, int max_iter = 1000, int random_state = -1,
-                                bool init_from_Y = false, int verbose = 0,
+                                int num_threads = 1, int max_iter = 1000, int n_iter_early_exag = 250,
+                                int random_state = -1, bool init_from_Y = false, int verbose = 0,
                                 double early_exaggeration = 12, double learning_rate = 200,
                                 double *final_error = NULL, int distance = 1)
     {
@@ -610,13 +610,13 @@ extern "C"
             fprintf(stderr, "Performing t-SNE using %d cores.\n", NUM_THREADS(num_threads));
         if (distance == 0) {
             TSNE<SplitTree, euclidean_distance> tsne;
-            tsne.run(X, N, D, Y, no_dims, perplexity, theta, num_threads, max_iter, random_state,
-                     init_from_Y, verbose, early_exaggeration, learning_rate, final_error);
+            tsne.run(X, N, D, Y, no_dims, perplexity, theta, num_threads, max_iter, n_iter_early_exag,
+                     random_state, init_from_Y, verbose, early_exaggeration, learning_rate, final_error);
         }
         else {
             TSNE<SplitTree, euclidean_distance_squared> tsne;
-            tsne.run(X, N, D, Y, no_dims, perplexity, theta, num_threads, max_iter, random_state,
-                     init_from_Y, verbose, early_exaggeration, learning_rate, final_error);
+            tsne.run(X, N, D, Y, no_dims, perplexity, theta, num_threads, max_iter, n_iter_early_exag,
+                     random_state, init_from_Y, verbose, early_exaggeration, learning_rate, final_error);
         }
     }
 }

--- a/multicore_tsne/tsne.h
+++ b/multicore_tsne/tsne.h
@@ -21,8 +21,8 @@ class TSNE
 public:
     void run(double* X, int N, int D, double* Y,
                int no_dims = 2, double perplexity = 30, double theta = .5,
-               int num_threads = 1, int max_iter = 1000, int random_state = 0,
-               bool init_from_Y = false, int verbose = 0,
+               int num_threads = 1, int max_iter = 1000, int n_iter_early_exag = 250,
+               int random_state = 0, bool init_from_Y = false, int verbose = 0,
                double early_exaggeration = 12, double learning_rate = 200,
                double *final_error = NULL);
     void symmetrizeMatrix(int** row_P, int** col_P, double** val_P, int N);


### PR DESCRIPTION
Adding argument to allow setting of the number of iterations that the algorithm stays in the early exaggeration phase.

This argument sets the values for two algorithm params that aren't currently exposed: `stop_lying_iter` and `mom_switch_iter`. It doesn't seem like these two variables ever get set to different values, thus a single argument to control them both should be fine in practice.

Controlling the learning rate in concert with the number of early exaggeration iterations and total iterations can produce a high quality embedding in a shorter time interval. This interplay is discussed at https://doi.org/10.1101/451690.