### PR TITLE
Small fix to allow compilation

### DIFF
--- a/multicore_tsne/splittree.cpp
+++ b/multicore_tsne/splittree.cpp
@@ -194,7 +194,7 @@ void SplitTree::subdivide() {
         
         SplitTree* qt = new SplitTree(this, data, mean_Y, width_Y);        
         children.push_back(qt);
-        delete[] mean_y;
+        delete[] mean_Y;
         delete[] width_Y;
         delete[] bits; 
     }


### PR DESCRIPTION
Tiny fix for issue #62, compiles fine and `pip install .` now works. The problem was a simple typo.